### PR TITLE
[fix] Add missing channel of JP country.

### DIFF
--- a/dot11ah_channel.c
+++ b/dot11ah_channel.c
@@ -181,6 +181,7 @@ static const country_channel_map_t jp_channel_map = {
 	.num_mapped_channels = 11,
 	.ah_vals = {
 		/* 1 Mhz */
+		{108, 9, 921, 0},
 		{36, 13, 923, 0},
 		{40, 15, 924, 0},
 		{44, 17, 925, 0},


### PR DESCRIPTION
	Country JP, Channel 9, 921 Mhz is defined in morse-regdb, so
	it should be added here.
	The 5Ghz mapping channel is verified by iw.